### PR TITLE
Implemented retry on Marketo API to fix 10 concurrent jobs issue. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # das-digital-engagement
 
 [![Build Status](https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_apis/build/status/das-campaign-functions)](https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/latest?definitionId=1309)
+
+## Overview
+
+A collection of Azure Functions which allow lead information to be imported into Marketo (SaaS Digital Engagement platform).  There are two main ways in which lead information is imported.  Firstly, via a manual CSV file upload, and secondly via an automated upload of employer leads taken from the service.
+
+### CSV upload
+
+A CSV file containing lead information can be uploaded to BLOB storage, which triggers an Azure function.  The function validates the CSV file and uploads it to Marketo.  A report is created (again, in BLOB storage) which details any issues in processing the import.  Such imports are adhoc, and the data in Marketo will only be updated again as and when an updated CSV file is uploaded for processing.
+
+### Automated Employer Contact upload
+
+An Azure function runs on a schedule (CRON), and on each execution all employer lead information is read from the Apprenticeship Service and imported into Marketo (whole dataset each time, not deltas).  As this is run on a schedule, on-service employer leads are always up to date in Marketo.  The import populates two items in Marketo, the out the box Lead object, and also a custom object to hold extended attributes.  A report is created (again, in BLOB storage) which details any issues in processing the import.
+
+## Running locally
+
+In order to run this repo locally, you will need follow the standard Microsoft instructions for running any Azure Functions locally - this is a prerequisite.  Additionally, you will require local Storage Account emulation, and  will need a local.settings.json with appropriate values.
+
+This repo uses the standard Apprenticeship Service approach of configuration in table storage.  The configuration should be copied to your local Storage Account following the standard Apprenticeship Service model.
+
+If debugging a CRON based Azure Function, it is recommended that you modify the CRON schedule to be something that will not interfere with your debugging session.  For example, you could use "0 0 1 * *", which is once per month, on the first of the month.  This then allows you to trigger the function manually, without fear of multiple execution of the function occurring during the debug session.
+
+To trigger the function locally, you can POST a request to the following URL (standard Azure Function local debug approach).
+
+http://localhost:7071/admin/functions/ImportDataMartData

--- a/azure/template.json
+++ b/azure/template.json
@@ -275,6 +275,10 @@
                                 "value": "[parameters('configurationStorageConnectionString')]"
                             },
                             {
+                                "name": "AppName",
+                                "value": "das-digital-engagement-employer-import"
+                            },
+                            {
                                 "name": "FUNCTIONS_WORKER_RUNTIME",
                                 "value": "dotnet"
                             }

--- a/src/DAS.DigitalEngagement.Application.UnitTests/Import/Handlers/WhenHandlingImportCampaignMembersRequest.cs
+++ b/src/DAS.DigitalEngagement.Application.UnitTests/Import/Handlers/WhenHandlingImportCampaignMembersRequest.cs
@@ -15,6 +15,8 @@ using Das.Marketo.RestApiClient.Models;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using Das.Marketo.RestApiClient.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace DAS.DigitalEngagement.Application.UnitTests.Import.Handlers
 {
@@ -27,7 +29,7 @@ namespace DAS.DigitalEngagement.Application.UnitTests.Import.Handlers
         private Mock<ILogger<ImportCampaignMembersHandler>> _logger;
         private Mock<IReportService> _reportService;
 
-        private IChunkingService _chunkingService = new ChunkingService();
+        private IChunkingService _chunkingService;
 
         private string _testCsv = CsvTestHelper.GetValidCsv_SingleChunk();
         private IList<dynamic> _testLeadList = GenerateNewLeads(10);
@@ -40,8 +42,10 @@ namespace DAS.DigitalEngagement.Application.UnitTests.Import.Handlers
             _bulkImportService = new Mock<IBulkImportService>();
             _logger = new Mock<ILogger<ImportCampaignMembersHandler>>();
             _reportService = new Mock<IReportService>();
+            var marketoConfig = new Mock<IOptions<MarketoConfiguration>>();
+            marketoConfig.Setup(x => x.Value.ChunkSizeKB).Returns(10000);    // 10MB chunk size
 
-
+            _chunkingService = new ChunkingService(marketoConfig.Object);
             _csvService.Setup(s => s.ConvertToList(It.IsAny<StreamReader>())).ReturnsAsync(_testLeadList);
             _chunkingServiceMock.Setup(s => s.GetChunks(It.IsAny<int>(),_testLeadList))
                 .Returns(new List<IList<dynamic>>());

--- a/src/DAS.DigitalEngagement.Application.UnitTests/Services/CsvServiceTests.cs
+++ b/src/DAS.DigitalEngagement.Application.UnitTests/Services/CsvServiceTests.cs
@@ -19,8 +19,6 @@ namespace DAS.DigitalEngagement.Application.UnitTests.Import.Handlers
         private string _testCsvSmall = CsvTestHelper.GetValidCsv(10, "Mickey", "Mouse", "Disney");
         private string _testCsvLarge = CsvTestHelper.GetValidCsv(700000,"Donald","Duck","Disney");
 
-        private IChunkingService _chunkingService = new ChunkingService();
-
         [SetUp]
         public void Arrange()
         {

--- a/src/DAS.DigitalEngagement.Application/DAS.DigitalEngagement.Application.csproj
+++ b/src/DAS.DigitalEngagement.Application/DAS.DigitalEngagement.Application.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="SFA.DAS.EmployerUsers.Api.Client" Version="1.0.0.52781" />
     <PackageReference Include="SFA.DAS.EmployerUsers.Api.Types" Version="1.0.0.52781" />
     <PackageReference Include="System.Net.Requests" Version="4.0.11" />

--- a/src/DAS.DigitalEngagement.Application/Handlers/Import/ImportDataMartHandler.cs
+++ b/src/DAS.DigitalEngagement.Application/Handlers/Import/ImportDataMartHandler.cs
@@ -35,7 +35,7 @@ namespace DAS.DigitalEngagement.Application.Import.Handlers
 
         public async Task<BulkImportStatus> Handle(DataMartSettings config)
         {
-            _logger.LogInformation($"about to handle person import");
+            _logger.LogInformation($"about to handle employer lead import");
 
 
             var data = _dataMartRepository.RetrieveViewData(config.ViewName);

--- a/src/DAS.DigitalEngagement.Application/Services/ChunkingService.cs
+++ b/src/DAS.DigitalEngagement.Application/Services/ChunkingService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Das.Marketo.RestApiClient.Configuration;
 using DAS.DigitalEngagement.Domain.Services;
 using DAS.DigitalEngagement.Models.Infrastructure;
 using Microsoft.Extensions.Options;
@@ -11,19 +12,22 @@ namespace DAS.DigitalEngagement.Application.Services
     public class ChunkingService : IChunkingService
     {
         public readonly ChunkingOptions _chunkingOptions;
+        private readonly IOptions<MarketoConfiguration> _marketoOptions;
 
-        public ChunkingService()
+        public ChunkingService(IOptions<MarketoConfiguration> marketoOptions)
         {
             _chunkingOptions = new ChunkingOptions();
+            _marketoOptions = marketoOptions;
         }
-        public ChunkingService(IOptions<ChunkingOptions> chunkingOptions)
+        public ChunkingService(IOptions<ChunkingOptions> chunkingOptions, IOptions<MarketoConfiguration> marketoOptions)
         {
             _chunkingOptions = chunkingOptions.Value;
+            _marketoOptions = marketoOptions;
         }
 
         private int CalculateChunkSize(int itemCount, long myBlobLength)
         {
-            var maxSize = _chunkingOptions.maxSize * 1000000;
+            var maxSize = _marketoOptions.Value.ChunkSizeKB * ChunkingOptions.BytesInKB;
 
             //Calculate the total number of items in a chunk. This allows for 5% just in case some items in the list are larger than the average.   
             var totalChunks = (int)Math.Ceiling(myBlobLength / (maxSize * _chunkingOptions.maxDensity));

--- a/src/DAS.DigitalEngagement.Application/Services/Marketo/MarketoDataModelConfigurationService.cs
+++ b/src/DAS.DigitalEngagement.Application/Services/Marketo/MarketoDataModelConfigurationService.cs
@@ -32,28 +32,31 @@ namespace DAS.DigitalEngagement.Application.Services.Marketo
         public async Task ConfigureTable(Table tableDefinition)
         {
 
-            //Check if object already exists
+            //Try and pull back the definition of the custom object
             var customObject = await _customObjectSchemaClient.GetCustomObjectSchema(tableDefinition.apiName);
 
-            //if doesnt exist
-            if (String.IsNullOrWhiteSpace(customObject.ApiName))
+            //check if custom object exists in marketo
+            if (customObject != null  && customObject.Success && customObject.Result.FirstOrDefault().Approved != null)
             {
-                //Create custom object
+                _logger.LogInformation("Custom object: {tableDefinition.apiName} already exists in Marketo, and is approved, so no need to create");
+            }
+            else if (null == customObject)
+            {
+                _logger.LogError($"Error retrieving Custom Object: {tableDefinition.apiName}");
+            }
+            else
+            {
+                _logger.LogWarning($"Custom Object: {tableDefinition.apiName} does NOT exist in Marketo or is NOT approved - so trying to create it");
 
+                //Create custom object
                 if (await CreateCustomObject(tableDefinition) == false) return;
 
                 //Create custom object fields
-                if (await CreateCustomObjectFields(tableDefinition, customObject) == false) return;
+                if (await CreateCustomObjectFields(tableDefinition) == false) return;
 
                 //approve object
                 await ApproveCustomObject(tableDefinition);
             }
-            else
-            {
-                _logger.LogWarning("Custom object already exists so cannot create");
-
-            }
-
         }
 
         private async Task<bool> ApproveCustomObject(Table tableDefinition)
@@ -62,13 +65,13 @@ namespace DAS.DigitalEngagement.Application.Services.Marketo
 
             if (customObjectSchemaResponse.Success == false)
             {
-                _logger.LogError($"Unable to create custom object, Response: {customObjectSchemaResponse}");
+                _logger.LogError($"Unable to approve custom object: {tableDefinition.apiName}, Response: {customObjectSchemaResponse}");
                 return false;
             }
             return true;
         }
 
-        private async Task<bool> CreateCustomObjectFields(Table tableDefinition, CustomObject customObject)
+        private async Task<bool> CreateCustomObjectFields(Table tableDefinition)
         {
             var customObjectSchemaResponse =
                 await _customObjectSchemaClient.PushCustomObjectFields(tableDefinition.apiName,
@@ -76,7 +79,7 @@ namespace DAS.DigitalEngagement.Application.Services.Marketo
 
             if (customObjectSchemaResponse.Success == false)
             {
-                _logger.LogError($"Unable to create custom object fields, Response: {customObjectSchemaResponse.ToString()}");
+                _logger.LogError($"Unable to create custom object fields for : {tableDefinition.apiName}, Response: {customObjectSchemaResponse.ToString()}");
                 return false;
             }
 
@@ -89,7 +92,7 @@ namespace DAS.DigitalEngagement.Application.Services.Marketo
 
             if (customObjectSchemaResponse.Success == false)
             {
-                _logger.LogError($"Unable to create custom object, Response: {customObjectSchemaResponse.ToString()}");
+                _logger.LogError($"Unable to create custom object: {tableDefinition.apiName}, Response: {customObjectSchemaResponse.ToString()}");
                 return false;
             }
 

--- a/src/DAS.DigitalEngagement.Application/Services/Marketo/MarketoDataModelConfigurationService.cs
+++ b/src/DAS.DigitalEngagement.Application/Services/Marketo/MarketoDataModelConfigurationService.cs
@@ -31,32 +31,31 @@ namespace DAS.DigitalEngagement.Application.Services.Marketo
 
         public async Task ConfigureTable(Table tableDefinition)
         {
-
             //Try and pull back the definition of the custom object
             var customObject = await _customObjectSchemaClient.GetCustomObjectSchema(tableDefinition.apiName);
-
-            //check if custom object exists in marketo
-            if (customObject != null  && customObject.Success && customObject.Result.FirstOrDefault().Approved != null)
-            {
-                _logger.LogInformation("Custom object: {tableDefinition.apiName} already exists in Marketo, and is approved, so no need to create");
-            }
-            else if (null == customObject)
+            if (null == customObject)
             {
                 _logger.LogError($"Error retrieving Custom Object: {tableDefinition.apiName}");
+                return;
             }
-            else
+
+            //check if custom object exists in marketo
+            if (customObject.Success && customObject.Result.FirstOrDefault().Approved != null)
             {
-                _logger.LogWarning($"Custom Object: {tableDefinition.apiName} does NOT exist in Marketo or is NOT approved - so trying to create it");
-
-                //Create custom object
-                if (await CreateCustomObject(tableDefinition) == false) return;
-
-                //Create custom object fields
-                if (await CreateCustomObjectFields(tableDefinition) == false) return;
-
-                //approve object
-                await ApproveCustomObject(tableDefinition);
+                _logger.LogInformation("Custom object: {tableDefinition.apiName} already exists in Marketo, and is approved, so no need to create");
+                return;
             }
+
+            _logger.LogWarning($"Custom Object: {tableDefinition.apiName} does NOT exist in Marketo or is NOT approved - so trying to create it");
+
+            //Create custom object
+            if (await CreateCustomObject(tableDefinition) == false) return;
+
+            //Create custom object fields
+            if (await CreateCustomObjectFields(tableDefinition) == false) return;
+
+            //approve object
+            await ApproveCustomObject(tableDefinition);
         }
 
         private async Task<bool> ApproveCustomObject(Table tableDefinition)

--- a/src/DAS.DigitalEngagement.Models/Infrastructure/ChunkingOptions.cs
+++ b/src/DAS.DigitalEngagement.Models/Infrastructure/ChunkingOptions.cs
@@ -2,7 +2,7 @@
 {
     public class ChunkingOptions
     {
-        public int maxSize { get; set; } = 10;
+        public const int BytesInKB = 1000;
         public double maxDensity { get; set; } = 0.95;
     }
 }

--- a/src/Das.Marketo.RestApiClient/Configuration/MarketoConfiguration.cs
+++ b/src/Das.Marketo.RestApiClient/Configuration/MarketoConfiguration.cs
@@ -7,6 +7,9 @@
         public virtual string ApiClientSecret { get; set; }
         public virtual RegisterInterestProgramConfiguration RegisterInterestProgramConfiguration { get; set; }
         public virtual string ApiIdentityBaseUrl { get; set; }
+        public virtual int ApiRetryCount { get; set; }
+        public virtual int ApiRetryInitialBackOffSecs { get; set; }
+        public virtual int ChunkSizeKB { get; set; }
 
         public virtual string ApiRestPrefix => "/rest/v1";
         public virtual string ApiBulkImportPrefix => "/bulk/v1";

--- a/src/Das.Marketo.RestApiClient/Interfaces/IMarketoCustomObjectClient.cs
+++ b/src/Das.Marketo.RestApiClient/Interfaces/IMarketoCustomObjectClient.cs
@@ -11,7 +11,7 @@ namespace Das.Marketo.RestApiClient.Interfaces
     public interface IMarketoCustomObjectSchemaClient
     {
         [Get("/customobjects/schema/{apiName}/describe.json")]
-        Task<CustomObject> GetCustomObjectSchema([AliasAs("apiName")] string name);
+        Task<Response<CustomObjectResponse>> GetCustomObjectSchema([AliasAs("apiName")] string name);
 
         [Post("/customobjects/schema.json")]
         Task<ResponseWithoutResult> PushCustomObjectSchema([Body(buffered: true)] CreateCustomObjectSchemaRequest customObjectSchema);

--- a/src/Das.Marketo.RestApiClient/Models/CustomObjectResponse.cs
+++ b/src/Das.Marketo.RestApiClient/Models/CustomObjectResponse.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Das.Marketo.RestApiClient.Models
+{
+    public class CustomObjectResponse
+    {
+        public string State { get; set; }
+        public CustomObjectStateSummary Approved { get; set; }
+    }
+
+    public class CustomObjectStateSummary
+    {
+        public string DisplayName { get; set; }
+        public string Description { get; set; }
+        public string ApiName { get; set; }
+    }
+}


### PR DESCRIPTION
The employer import pulls contact data from the Data Mart, and pushes this data into Marketo via the Marketo REST API.

There is a restriction in Marketo, that limits the total number of queued and active import jobs to 10.  When the limit of 10 is hit, the REST API call fails (stating 10 are already active).  

This branch implements logic to detect that condition, and retry the API call using an exponential back off.  The idea being that the delay will be sufficient to allow Marketo to have cleared some of its existing job backlog, allowing it to accept a new request on a subsequent retry.

The branch also fixes an issue relating to creating custom object in marketo if it is not already present.

The scope of the work was to fix the issue in production.  However, it should be noted that the overall design approach is not really appropriate.  It would be a better design if it monitored job status before submitting new jobs, to remove the need for a retry in the first place.  Such a major change was outside of the scope of this work.