### PR TITLE
updated das-platform-building-blocks to 2.1.28

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.0
+    ref: refs/tags/2.1.28
     endpoint: SkillsFundingAgency
 
 stages:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -18,6 +18,7 @@ jobs:
   - template: azure-pipelines-templates/build/step/app-build.yml@das-platform-building-blocks
     parameters:
       SonarCloudProjectKey: SkillsFundingAgency_das-digital-engagement
+      ContinueOnVulnerablePackageScanError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Publish DataCollection Function'


### PR DESCRIPTION
Upgrading seems to have had no adverse effects:
Build:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/results?buildId=814368&view=results
Release:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-environment-logs&releaseId=109010&environmentId=507426